### PR TITLE
Update linkwith.cs to link required frameworks

### DIFF
--- a/AppsFlyerXamarinBinding/libAppsFlyerLib.linkwith.cs
+++ b/AppsFlyerXamarinBinding/libAppsFlyerLib.linkwith.cs
@@ -1,4 +1,4 @@
 using ObjCRuntime;
 
 [assembly: LinkWith ("libAppsFlyerLib.a", SmartLink = true, ForceLoad = true)]
-[assembly: LinkWith ("libAppsFlyerLib.a", SmartLink = true, Frameworks="Security")]
+[assembly: LinkWith ("libAppsFlyerLib.a", SmartLink = true, Frameworks="Security iAd", WeakFrameworks="AdSupport")]


### PR DESCRIPTION
The [iOS integration documentation](https://support.appsflyer.com/hc/en-us/articles/207032066-iOS-SDK-Integration-Guide-v3-3-x-New-API-#What's_New_in_This_Version) mentions that we need to add the iAd.framework and AdSupport.framework to get the full features of Appsflyer. 

This should be done within the linkwith.cs file in the binding project.